### PR TITLE
packit: fix version string

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,6 +8,9 @@ upstream_package_name: resalloc-ibm-cloud
 downstream_package_name: resalloc-ibm-cloud
 upstream_project_url: https://github.com/fedora-copr/resalloc-ibm-cloud
 
+actions:
+  get-current-version:
+    - bash -c "git describe --tags --match 'resalloc-ibm-cloud-[0-9]*' --abbrev=0 HEAD | grep -E -o '[0-9]+\.[0-9]+'"
 
 files_to_sync:
   - resalloc-ibm-cloud.spec


### PR DESCRIPTION
This leads to this change:

- resalloc-ibm-cloud-resalloc.ibm.cloud.1.0.1-1.20231013061132423302.main.3.g41cb5b7.fc39.src.rpm
+ resalloc-ibm-cloud-1.0-1.20231013082227670739.main.4.gfab0605.fc39.src.rpm