### PR TITLE
Fix vm listing traceback and manpage strings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,6 @@ build_manpages = "build_manpages.build_manpages"
 [tool.build_manpages]
 manpages = [
     "man/resalloc-ibm-cloud-vm.1:function=vm_arg_parser:pyfile=resalloc_ibm_cloud/argparsers.py",
-    "man/resalloc-ibm-cloud-list-vms.1:function=vm_list_arg_parser:pyfile=resalloc_ibm_cloud/argparsers.py",
-    "man/resalloc-ibm-cloud-list-deleting-vms.1:function=default_arg_parser:pyfile=resalloc_ibm_cloud/argparsers.py",
+    "man/resalloc-ibm-cloud-list-vms.1:function=list_vms_parser:pyfile=resalloc_ibm_cloud/argparsers.py",
+    "man/resalloc-ibm-cloud-list-deleting-vms.1:function=list_deleting_vms_parser:pyfile=resalloc_ibm_cloud/argparsers.py",
 ]

--- a/resalloc_ibm_cloud/argparsers.py
+++ b/resalloc_ibm_cloud/argparsers.py
@@ -5,12 +5,16 @@ ArgumentParser getters on one place, this simplifies generating manual pages.
 import argparse
 
 
-def default_arg_parser():
+def _pfx(name):
+    return "resalloc-ibm-cloud-" + name
+
+
+def _default_arg_parser(prog=None):
     """
     The part that every resalloc-ibm-cloud utility needs
     """
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog=prog)
     parser.add_argument(
         "--token-file", help="Path to IBM cloud token file", required=True
     )
@@ -26,7 +30,7 @@ def vm_arg_parser():
     """
     Parser for the resalloc-ibm-cloud-vm utility.
     """
-    parser = default_arg_parser()
+    parser = _default_arg_parser(prog=_pfx("vm"))
     parser.add_argument("--log-level", default="info")
 
     subparsers = parser.add_subparsers(dest="subparser")
@@ -66,10 +70,18 @@ def vm_arg_parser():
     return parser
 
 
-def vm_list_arg_parser():
+def _list_arg_parser(prog=None):
     """
-    Parser for the resalloc-ibm-cloud-list-vms utility.
+    Parser for listing utilities
     """
-    parser = default_arg_parser()
+    parser = _default_arg_parser(prog=prog)
     parser.add_argument("--pool")
     return parser
+
+def list_deleting_vms_parser():
+    """ parser for listing vms """
+    return _list_arg_parser(prog=_pfx("list-deleting-vms"))
+
+def list_vms_parser():
+    """ parser for listing deleting vms """
+    return _list_arg_parser(prog=_pfx("list-vms"))

--- a/resalloc_ibm_cloud/ibm_cloud_list_deleting_vms.py
+++ b/resalloc_ibm_cloud/ibm_cloud_list_deleting_vms.py
@@ -3,14 +3,14 @@ List all IBM Cloud instances that are in Deleting state
 """
 
 from resalloc_ibm_cloud.helpers import get_service
-from resalloc_ibm_cloud.argparsers import default_arg_parser
+from resalloc_ibm_cloud.argparsers import list_deleting_vms_parser
 from resalloc_ibm_cloud.constants import LIMIT
 
 
 def main():
     """Entrypoint to the script."""
 
-    opts = default_arg_parser().parse_args()
+    opts = list_deleting_vms_parser().parse_args()
     cmd = f"source {opts.token_file} ; echo $IBMCLOUD_API_KEY"
     service = get_service(cmd, opts)
 

--- a/resalloc_ibm_cloud/ibm_cloud_list_vms.py
+++ b/resalloc_ibm_cloud/ibm_cloud_list_vms.py
@@ -6,14 +6,14 @@ import os
 import sys
 
 from resalloc_ibm_cloud.helpers import get_service
-from resalloc_ibm_cloud.argparsers import default_arg_parser
+from resalloc_ibm_cloud.argparsers import list_vms_parser
 from resalloc_ibm_cloud.constants import LIMIT
 
 
 def main():
     """An entrypoint to the script."""
 
-    opts = default_arg_parser().parse_args()
+    opts = list_vms_parser().parse_args()
 
     pool_id = opts.pool or os.getenv("RESALLOC_POOL_ID")
     if not pool_id:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/resalloc-ibm-cloud-list-vms", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.12/site-packages/resalloc_ibm_cloud/ibm_cloud_list_vms.py", line 18, in main
    pool_id = opts.pool or os.getenv("RESALLOC_POOL_ID")
              ^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'pool'

The manpages contained `argparsers.py` string, instead of the utility name, therefore defining prog= now.