### PR TITLE
Fail early for too long instance names

### DIFF
--- a/resalloc_ibm_cloud/ibm_cloud_vm.py
+++ b/resalloc_ibm_cloud/ibm_cloud_vm.py
@@ -124,6 +124,21 @@ def _get_private_ip_of_instance(instance_id, service):
     raise TimeoutError("Instance creation took too much time")
 
 
+def check_field_len(log, config, itemspec, max_length):
+    """
+    Check that CONFIG dict (sub-)item specified by ITEMSPEC (list of hashable
+    objects determining the location in the dict) has length <= MAX_LENGTH.
+    """
+    to_check = config
+    for i in itemspec:
+        to_check = to_check[i]
+    if len(to_check) <= max_length:
+        return
+    log.error("Field %s is longer than %s characters: %s",
+              ".".join(itemspec), max_length, to_check)
+    sys.exit(1)
+
+
 def create_instance(service, instance_name, opts):
     """
     Start the VM, name it "instance_name"
@@ -172,6 +187,13 @@ def create_instance(service, instance_name, opts):
             }
         ],
     }
+
+    for items in [
+        ["name"],
+        ["boot_volume_attachment", "volume", "name"],
+        ["volume_attachments", 0, "volume", "name"],
+    ]:
+        check_field_len(log, instance_prototype_model, items, 63)
 
     ip_address = None
     instance_created = None


### PR DESCRIPTION
The resource name length in IBM Cloud needs to be <= 63 characters.
If we attempt to allocate a set of resources (machine, volumes, IP, ...)
and one of the names for those resources is too long, the library fails
with pretty cryptic traceback:

    Traceback (most recent call last):
      File "/usr/bin/resalloc-ibm-cloud-vm", line 8, in <module>
        sys.exit(main())
                 ^^^^^^
      File "/usr/lib/python3.11/site-packages/resalloc_ibm_cloud/ibm_cloud_vm.py", line 348, in main
        create_instance(service, name, opts)
      File "/usr/lib/python3.11/site-packages/resalloc_ibm_cloud/ibm_cloud_vm.py", line 182, in create_instance
        response = service.create_instance(instance_prototype_model)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/ibm_vpc/vpc_v1.py", line 4583, in create_instance
        response = self.send(request, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/ibm_cloud_sdk_core/base_service.py", line 341, in send
        raise ApiException(response.status_code, http_response=response)
    ibm_cloud_sdk_core.api_exception.ApiException: Error: Expected only one oneOf fields to be set: got 0, Code: 400

With this fix, we'll get the failure much faster:

    ERROR: Field boot_volume_attachment.volume.name is longer than 63 characters: copr-ibm-cloud-s390x-washington-prod-13290257-20231024-201117-root
